### PR TITLE
Fix invalid lambda policy generated by "ANY" rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = class ExistingEventRulePlugin {
 
    _buildPermissionSourceArn(rule) {
      if (rule.startsWith('arn')) { return rule; }
-     const source = rule === 'ANY' ? '*' : rule;
+     const source = rule === 'ANY' ? 'rule/*' : rule;
      return { 'Fn::Join': [ ':', [ 'arn:aws:events', { 'Ref': 'AWS::Region' }, { 'Ref': 'AWS::AccountId' }, source ] ] };
    }
 


### PR DESCRIPTION
It seems like the "ANY" rule doesn't actually work because it generates an invalid lambda policy.

Here's the relevant part from my serverless.yml:
```
  getClusterMetrics:
    handler: scaling.getClusterMetrics
    timeout: 30
    events: 
    - cloudWatchRule: ANY
```

The function gets the following policy:
```
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "operations-dev-GetClusterMetricsLambdaPermissionANY-ZOA748HJUOCH",
      "Effect": "Allow",
      "Principal": {
        "Service": "events.amazonaws.com"
      },
      "Action": "lambda:InvokeFunction",
      "Resource": "arn:aws:lambda:eu-west-2:123456789012:function:operations-dev-getClusterMetrics",
      "Condition": {
        "ArnLike": {
          "AWS:SourceArn": "arn:aws:events:eu-west-2:123456789012:*"
        }
      }
    }
  ]
}
```

This rule doesn't work, all the invocations fail. The AWS documentation does seem to agree:

> You cannot use a wildcard in the portion of the ARN that specifies the resource type, such as the term user in an IAM ARN.
> 
> `arn:aws:iam::123456789012:u*`

And if I generate this through the cloudwatch console it actually generates this policy:
```
{
  "Version": "2012-10-17",
  "Id": "default",
  "Statement": [
    {
      "Sid": "AWSEvents_ecs-cluster-dev-metrics_Id1772996521410",
      "Effect": "Allow",
      "Principal": {
        "Service": "events.amazonaws.com"
      },
      "Action": "lambda:InvokeFunction",
      "Resource": "arn:aws:lambda:eu-west-2:123456789012:function:operations-dev-getClusterMetrics",
      "Condition": {
        "ArnLike": {
          "AWS:SourceArn": "arn:aws:events:eu-west-2:123456789012:rule/ecs-cluster-dev-metrics"
        }
      }
    }
  ]
}
```

Which does work.

Changing the `*` to `rule/*` in the AWS:SourceArn condition should fix this.
